### PR TITLE
SPEC0 Python updates; pixi gitignores

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -22,9 +22,9 @@ jobs:
       matrix:
         os: ['ubuntu']
         python-version:
-          - "3.9"
-          - "3.10"
           - "3.11"
+          - "3.12"
+          - "3.13"
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4

--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,7 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# pixi environments
+.pixi
+*.egg-info


### PR DESCRIPTION
Just a little start-of-year maintenance. Adding Python 3.12, 3.13 to test matrix, and now that I'm playing with `pixi`, taking its default recommendations for the gitignore.